### PR TITLE
Correção de erro de ObjectOutputStream

### DIFF
--- a/src/main/java/hash/client/HashTcpClient.java
+++ b/src/main/java/hash/client/HashTcpClient.java
@@ -50,6 +50,10 @@ public class HashTcpClient {
         String value;
         Message toServer;
         Message fromServer;
+
+        ObjectOutputStream requestAdd = new ObjectOutputStream(client.getOutputStream());
+        ObjectInputStream responseAdd = new ObjectInputStream(client.getInputStream());
+
         switch (option) {
             case 1:
                 System.out.print("Digite a chave: ");
@@ -59,10 +63,9 @@ public class HashTcpClient {
                 value = input.next();
 
                 toServer = new Message(0,key.length(),key,value.length(),value,4);
-                ObjectOutputStream requestAdd = new ObjectOutputStream(client.getOutputStream());
+
                 requestAdd.writeObject(toServer);
 
-                ObjectInputStream responseAdd = new ObjectInputStream(client.getInputStream());
                 fromServer = (Message) responseAdd.readObject();
                 System.out.println(handleMessage(fromServer));
                 break;
@@ -72,11 +75,9 @@ public class HashTcpClient {
                 key = input.next();
 
                 toServer = new Message(1,key.length(),key,0,"",4);
-                ObjectOutputStream requestRead = new ObjectOutputStream(client.getOutputStream());
-                requestRead.writeObject(toServer);
+                requestAdd.writeObject(toServer);
 
-                ObjectInputStream responseRead = new ObjectInputStream(client.getInputStream());
-                fromServer = (Message) responseRead.readObject();
+                fromServer = (Message) responseAdd.readObject();
                 System.out.println(handleMessage(fromServer));
                 break;
 
@@ -88,11 +89,9 @@ public class HashTcpClient {
                 value = input.next();
 
                 toServer = new Message(2,key.length(),key,value.length(),value,4);
-                ObjectOutputStream requestUpdate = new ObjectOutputStream(client.getOutputStream());
-                requestUpdate.writeObject(toServer);
+                requestAdd.writeObject(toServer);
 
-                ObjectInputStream responseUpdate = new ObjectInputStream(client.getInputStream());
-                fromServer = (Message) responseUpdate.readObject();
+                fromServer = (Message) responseAdd.readObject();
 
                 System.out.println(handleMessage(fromServer));
                 break;
@@ -102,11 +101,9 @@ public class HashTcpClient {
                 key = input.next();
 
                 toServer = new Message(3,key.length(),key,0,"",4);
-                ObjectOutputStream requestDelete = new ObjectOutputStream(client.getOutputStream());
-                requestDelete.writeObject(toServer);
+                requestAdd.writeObject(toServer);
 
-                ObjectInputStream responseDelete = new ObjectInputStream(client.getInputStream());
-                fromServer = (Message) responseDelete.readObject();
+                fromServer = (Message) responseAdd.readObject();
                 System.out.println(handleMessage(fromServer));
                 break;
 

--- a/src/main/java/hash/server/ThreadHashServer.java
+++ b/src/main/java/hash/server/ThreadHashServer.java
@@ -21,10 +21,11 @@ public class ThreadHashServer extends Thread {
         //logica que o server vai fazer para o client
         try {
             ObjectInputStream entrance = new ObjectInputStream(client.getInputStream());
+            ObjectOutputStream response = new ObjectOutputStream(client.getOutputStream());
             Message m = (Message) entrance.readObject();
             System.out.println(m.toString());
 
-            operation(m);
+            operation(m, response);
 
             hashTable.showAll();
 
@@ -36,8 +37,8 @@ public class ThreadHashServer extends Thread {
         }
     }
 
-    public void operation(Message request) throws IOException {
-        ObjectOutputStream response = new ObjectOutputStream(client.getOutputStream());
+    public void operation(Message request,ObjectOutputStream response) throws IOException {
+
         Message message;
         int result;
         switch (request.getContent()) {


### PR DESCRIPTION
- Ajuste no arquivo de server para que seja instanciado logo após o InputStream.
- Ajuste no Client para que seja instanciado apenas uma vez o ObjectInputStream e ObjectOutputStream